### PR TITLE
Change module kind from `plain` to `umd` for use with Node.js

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ dependencies {
 	testCompile "junit:junit:$junit_version"
 }
 
+compileKotlin2Js {
+	kotlinOptions {
+		moduleKind = "umd"
+	}
+}
 
 // PUBLISHING
 


### PR DESCRIPTION
Thank you for creating JavaScript version.

I tried using this product with Node.js, but I could not use it.

If module kind is set to `umd`, it can correspond to various module kinds including CommonJS, so please change the module kind and publish it.

Best regards.